### PR TITLE
[AT] - WIDG-410

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -4,7 +4,7 @@
     <title>My Test SnapSVG shit</title>
   </head>
   <body>
-    <div id="svg-dial"></svg>
+    <div id="svg-dial"></div>
 
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/snap.svg/0.3.0/snap.svg-min.js"></script>
     <script type="text/javascript" src="../svg-dial.js"></script>

--- a/svg-dial.js
+++ b/svg-dial.js
@@ -191,18 +191,30 @@
         );
       };
 
-      var innerCircle = this.c.circle(
-        attributes.x,
-        attributes.y,
-        attributes.radius
-      );
+      var buildKnobCircle = function() {
+        return this.c.circle(
+          attributes.x,
+          attributes.y,
+          attributes.radius
+        )
+      };
+
       var dropShadow = this.generateDropShadow();
       var dialKnob = buildDialKnob.call(this);
 
-      var innerGrouping = this.c.group(innerCircle, dialKnob).attr({
+      var baseCircle = buildKnobCircle.call(this).attr({
+        fill: this.calculateFillColor(this.options.innerBackgroundColor),
+        filter: dropShadow
+      });
+
+      var innerGrouping = this.c.group(dialKnob).attr({
         fill: this.calculateFillColor(this.options.innerBackgroundColor),
         filter: dropShadow,
         transform: ['rotate(0', this.options.frameSize / 2, this.options.frameSize / 2].join(' ')
+      });
+
+      var capCircle = buildKnobCircle.call(this).attr({
+        fill: this.calculateFillColor(this.options.innerBackgroundColor)
       });
 
       return innerGrouping;


### PR DESCRIPTION
## What's this PR do?

If a user rotates a the dial, the dropshadow for the main circle no longer rotates. Knob arrow rotation should still animate as the dial is turned. Also fixed a closing tag in the demo index file.
## Where should the reviewer start?

Fire up the demo, move the knob around. The dial drop shadow shouldn't be moving, the arrow's shadow should, and the arrow's shadow should not interfere with the inner circle.
## What are the relevant tickets?

WIDG-410
